### PR TITLE
Fix baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,4 +111,4 @@ description: "FRC Team 4159 CardinalBotics' project documentation, references, a
 
 # needed for sitemap.xml file only
 url: https://team4159.github.io
-baseurl: /team4159.github.io
+baseurl:

--- a/_config.yml
+++ b/_config.yml
@@ -111,4 +111,4 @@ description: "FRC Team 4159 CardinalBotics' project documentation, references, a
 
 # needed for sitemap.xml file only
 url: https://team4159.github.io
-baseurl: /home
+baseurl: /team4159.github.io


### PR DESCRIPTION
I tested it with a forked repository, and that seemed to work alright, whether the baseurl was set to the project name or just left blank. 